### PR TITLE
[ecore][go] URIBuilder used to construct URI

### DIFF
--- a/ecore/binarydecoder.go
+++ b/ecore/binarydecoder.go
@@ -432,9 +432,7 @@ func (d *BinaryDecoder) decodeURI() *URI {
 		} else {
 			uri = d.uris[id]
 		}
-		uri = uri.Copy()
-		uri.fragment = d.decodeString()
-		return uri
+		return NewURIBuilder(uri).SetFragment(d.decodeString()).URI()
 	}
 }
 

--- a/ecore/binarydecoder.go
+++ b/ecore/binarydecoder.go
@@ -433,7 +433,7 @@ func (d *BinaryDecoder) decodeURI() *URI {
 			uri = d.uris[id]
 		}
 		uri = uri.Copy()
-		uri.Fragment = d.decodeString()
+		uri.fragment = d.decodeString()
 		return uri
 	}
 }

--- a/ecore/binarydecoder_test.go
+++ b/ecore/binarydecoder_test.go
@@ -18,7 +18,7 @@ func TestBinaryDecoder_Complex(t *testing.T) {
 	require.NotNil(t, ePackage)
 
 	//
-	uri := &URI{Path: "testdata/library.complex.bin"}
+	uri := NewURI("testdata/library.complex.bin")
 	eResource := NewEResourceImpl()
 	eResource.SetURI(uri)
 	eResourceSet := NewEResourceSetImpl()
@@ -26,7 +26,7 @@ func TestBinaryDecoder_Complex(t *testing.T) {
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
 
 	// file
-	f, err := os.Open(uri.Path)
+	f, err := os.Open(uri.String())
 	require.Nil(t, err)
 
 	binaryDecoder := NewBinaryDecoder(eResource, f, nil)
@@ -100,7 +100,7 @@ func TestBinaryDecoder_ComplexWithID(t *testing.T) {
 	require.NotNil(t, ePackage)
 
 	//
-	uri := &URI{Path: "testdata/library.complex.id.bin"}
+	uri := NewURI("testdata/library.complex.id.bin")
 	idManager := NewUniqueIDManager(20)
 	eResource := NewEResourceImpl()
 	eResource.SetURI(uri)
@@ -110,7 +110,7 @@ func TestBinaryDecoder_ComplexWithID(t *testing.T) {
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
 
 	// file
-	f, err := os.Open(uri.Path)
+	f, err := os.Open(uri.String())
 	require.Nil(t, err)
 
 	binaryDecoder := NewBinaryDecoder(eResource, f, nil)
@@ -139,7 +139,7 @@ func TestBinaryDecoder_SimpleWithEDataTypeList(t *testing.T) {
 	require.NotNil(t, ePackage)
 
 	//
-	uri := &URI{Path: "testdata/library.datalist.bin"}
+	uri := NewURI("testdata/library.datalist.bin")
 	idManager := NewUniqueIDManager(20)
 	eResource := NewEResourceImpl()
 	eResource.SetURI(uri)
@@ -149,7 +149,7 @@ func TestBinaryDecoder_SimpleWithEDataTypeList(t *testing.T) {
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
 
 	// file
-	f, err := os.Open(uri.Path)
+	f, err := os.Open(uri.String())
 	require.Nil(t, err)
 
 	binaryDecoder := NewBinaryDecoder(eResource, f, nil)
@@ -189,7 +189,7 @@ func TestBinaryDecoder_ComplexBig(t *testing.T) {
 	require.NotNil(t, ePackage)
 
 	//
-	uri := &URI{Path: "testdata/library.complex.big.bin"}
+	uri := NewURI("testdata/library.complex.big.bin")
 	eResource := NewEResourceImpl()
 	eResource.SetURI(uri)
 	eResourceSet := NewEResourceSetImpl()
@@ -197,7 +197,7 @@ func TestBinaryDecoder_ComplexBig(t *testing.T) {
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
 
 	// file
-	f, err := os.Open(uri.Path)
+	f, err := os.Open(uri.String())
 	require.Nil(t, err)
 
 	binaryDecoder := NewBinaryDecoder(eResource, f, nil)
@@ -211,7 +211,7 @@ func TestBinaryDecoder_Maps(t *testing.T) {
 	require.NotNil(t, ePackage)
 
 	//
-	uri := &URI{Path: "testdata/emap.bin"}
+	uri := NewURI("testdata/emap.bin")
 	eResource := NewEResourceImpl()
 	eResource.SetURI(uri)
 	eResourceSet := NewEResourceSetImpl()
@@ -219,7 +219,7 @@ func TestBinaryDecoder_Maps(t *testing.T) {
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
 
 	// file
-	f, err := os.Open(uri.Path)
+	f, err := os.Open(uri.String())
 	require.Nil(t, err)
 
 	binaryDecoder := NewBinaryDecoder(eResource, f, nil)
@@ -257,7 +257,7 @@ func BenchmarkBinaryDecoderLibraryComplexBig(b *testing.B) {
 	require.NotNil(b, ePackage)
 
 	// create resource
-	uri := &URI{Path: "testdata/library.complex.big.bin"}
+	uri := NewURI("testdata/library.complex.big.bin")
 	eResource := NewEResourceImpl()
 	eResource.SetURI(uri)
 	eResourceSet := NewEResourceSetImpl()
@@ -265,7 +265,7 @@ func BenchmarkBinaryDecoderLibraryComplexBig(b *testing.B) {
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
 
 	// get file content
-	content, err := ioutil.ReadFile(uri.Path)
+	content, err := ioutil.ReadFile(uri.String())
 	require.Nil(b, err)
 	require.Nil(b, err)
 	r := bytes.NewReader(content)

--- a/ecore/binaryencoder.go
+++ b/ecore/binaryencoder.go
@@ -373,7 +373,7 @@ func (e *BinaryEncoder) encodeURI(uri *URI) {
 	if uri == nil {
 		e.encodeInt(-1)
 	} else {
-		e.encodeURIWithFragment(uri.TrimFragment(), uri.Fragment)
+		e.encodeURIWithFragment(uri.TrimFragment(), uri.fragment)
 	}
 }
 

--- a/ecore/binaryencoder.go
+++ b/ecore/binaryencoder.go
@@ -373,7 +373,7 @@ func (e *BinaryEncoder) encodeURI(uri *URI) {
 	if uri == nil {
 		e.encodeInt(-1)
 	} else {
-		e.encodeURIWithFragment(uri.TrimFragment(), uri.fragment)
+		e.encodeURIWithFragment(uri.TrimFragment(), uri.Fragment())
 	}
 }
 

--- a/ecore/binaryencoder_test.go
+++ b/ecore/binaryencoder_test.go
@@ -16,7 +16,7 @@ func TestBinaryEncoder_Complex(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.LoadWithOptions(&URI{Path: "testdata/library.complex.xml"}, nil)
+	eResource := xmlProcessor.LoadWithOptions(NewURI("testdata/library.complex.xml"), nil)
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -41,7 +41,7 @@ func TestBinaryEncoder_ComplexWithID(t *testing.T) {
 	require.NotNil(t, ePackage)
 
 	// load resource
-	uri := &URI{Path: "testdata/library.complex.id.xml"}
+	uri := NewURI("testdata/library.complex.id.xml")
 	eResource := NewEResourceImpl()
 	eResource.SetURI(uri)
 	eResource.SetObjectIDManager(NewUniqueIDManager(20))
@@ -78,7 +78,7 @@ func TestBinaryEncoder_ComplexBig(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.LoadWithOptions(&URI{Path: "testdata/library.complex.big.xml"}, nil)
+	eResource := xmlProcessor.LoadWithOptions(NewURI("testdata/library.complex.big.xml"), nil)
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -103,7 +103,7 @@ func TestBinaryEncoder_SimpleWithDataTypeList(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.LoadWithOptions(&URI{Path: "testdata/library.datalist.xml"}, nil)
+	eResource := xmlProcessor.LoadWithOptions(NewURI("testdata/library.datalist.xml"), nil)
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -128,7 +128,7 @@ func TestBinaryEncoder_Maps(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.LoadWithOptions(&URI{Path: "testdata/emap.xml"}, nil)
+	eResource := xmlProcessor.LoadWithOptions(NewURI("testdata/emap.xml"), nil)
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -153,7 +153,7 @@ func BenchmarkBinaryEncoderLibraryComplexBig(b *testing.B) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.LoadWithOptions(&URI{Path: "testdata/library.complex.big.xml"}, nil)
+	eResource := xmlProcessor.LoadWithOptions(NewURI("testdata/library.complex.big.xml"), nil)
 	require.NotNil(b, eResource)
 	require.True(b, eResource.GetWarnings().Empty(), diagnosticError(eResource.GetWarnings()))
 

--- a/ecore/deepequal.go
+++ b/ecore/deepequal.go
@@ -60,7 +60,7 @@ func (dE *deepEqual) equals(eObj1 EObject, eObj2 EObject) bool {
 	if eObj1.EIsProxy() {
 		eURI1 := eObj1.(EObjectInternal).EProxyURI()
 		eURI2 := eObj2.(EObjectInternal).EProxyURI()
-		if (eURI1 != nil && eURI2 != nil && *eURI1 == *eURI2) || (eURI1 == nil && eURI2 == nil) {
+		if (eURI1 != nil && eURI1.Equals(eURI2)) || (eURI1 == nil && eURI2 == nil) {
 			dE.objects[eObj1] = eObj2
 			dE.objects[eObj2] = eObj1
 			return true

--- a/ecore/dynamiceobject_impl_test.go
+++ b/ecore/dynamiceobject_impl_test.go
@@ -160,14 +160,14 @@ func TestDynamicEObject_Proxy(t *testing.T) {
 
 	// add to resource to enable proxy resolution
 	resource := NewEResourceImpl()
-	resource.SetURI(&URI{Path: "r"})
+	resource.SetURI(NewURIBuilder(nil).SetPath("r").URI())
 	resource.GetContents().AddAll(NewImmutableEList([]interface{}{o1, o3}))
 
 	resourceSet := NewEResourceSetImpl()
 	resourceSet.GetResources().Add(resource)
 
 	oproxy := NewDynamicEObjectImpl()
-	oproxy.ESetProxyURI(&URI{Path: "r", fragment: "//@r1.1"})
+	oproxy.ESetProxyURI(NewURIBuilder(nil).SetPath("r").SetFragment("//@r1.1").URI())
 	assert.False(t, o3.EIsSet(r3))
 
 	o3.ESet(r3, oproxy)

--- a/ecore/dynamiceobject_impl_test.go
+++ b/ecore/dynamiceobject_impl_test.go
@@ -167,7 +167,7 @@ func TestDynamicEObject_Proxy(t *testing.T) {
 	resourceSet.GetResources().Add(resource)
 
 	oproxy := NewDynamicEObjectImpl()
-	oproxy.ESetProxyURI(&URI{Path: "r", Fragment: "//@r1.1"})
+	oproxy.ESetProxyURI(&URI{Path: "r", fragment: "//@r1.1"})
 	assert.False(t, o3.EIsSet(r3))
 
 	o3.ESet(r3, oproxy)

--- a/ecore/dynamicmodel_test.go
+++ b/ecore/dynamicmodel_test.go
@@ -160,26 +160,26 @@ func TestDynamicModel(t *testing.T) {
 func TestGetURINoResource(t *testing.T) {
 	mm := createDynamicMetaModel()
 	m := instanciateDynamicModel(mm)
-	assert.Equal(t, &URI{Fragment: "//"}, GetURI(m.bookStoreObject))
-	assert.Equal(t, &URI{Fragment: "//@books.0"}, GetURI(m.bookObject))
+	assert.Equal(t, &URI{fragment: "//"}, GetURI(m.bookStoreObject))
+	assert.Equal(t, &URI{fragment: "//@books.0"}, GetURI(m.bookObject))
 }
 
 func TestGetURIResource(t *testing.T) {
 	mm := createDynamicMetaModel()
 	m := instanciateDynamicModel(mm)
 	r := NewEResourceImpl()
-	r.SetURI(&URI{Scheme: "file",
+	r.SetURI(&URI{scheme: "file",
 		Path: "a.test",
 	})
 	c := r.GetContents()
 	c.Add(m.bookStoreObject)
-	assert.Equal(t, &URI{Scheme: "file",
+	assert.Equal(t, &URI{scheme: "file",
 		Path:     "a.test",
-		Fragment: "/",
+		fragment: "/",
 	}, GetURI(m.bookStoreObject))
-	assert.Equal(t, &URI{Scheme: "file",
+	assert.Equal(t, &URI{scheme: "file",
 		Path:     "a.test",
-		Fragment: "//@books.0",
+		fragment: "//@books.0",
 	}, GetURI(m.bookObject))
 }
 

--- a/ecore/dynamicmodel_test.go
+++ b/ecore/dynamicmodel_test.go
@@ -160,27 +160,19 @@ func TestDynamicModel(t *testing.T) {
 func TestGetURINoResource(t *testing.T) {
 	mm := createDynamicMetaModel()
 	m := instanciateDynamicModel(mm)
-	assert.Equal(t, &URI{fragment: "//"}, GetURI(m.bookStoreObject))
-	assert.Equal(t, &URI{fragment: "//@books.0"}, GetURI(m.bookObject))
+	assert.Equal(t, NewURI("#//"), GetURI(m.bookStoreObject))
+	assert.Equal(t, NewURI("#//@books.0"), GetURI(m.bookObject))
 }
 
 func TestGetURIResource(t *testing.T) {
 	mm := createDynamicMetaModel()
 	m := instanciateDynamicModel(mm)
 	r := NewEResourceImpl()
-	r.SetURI(&URI{scheme: "file",
-		Path: "a.test",
-	})
+	r.SetURI(NewURI("file:/a.test"))
 	c := r.GetContents()
 	c.Add(m.bookStoreObject)
-	assert.Equal(t, &URI{scheme: "file",
-		Path:     "a.test",
-		fragment: "/",
-	}, GetURI(m.bookStoreObject))
-	assert.Equal(t, &URI{scheme: "file",
-		Path:     "a.test",
-		fragment: "//@books.0",
-	}, GetURI(m.bookObject))
+	assert.Equal(t, NewURI("file:/a.test#/"), GetURI(m.bookStoreObject))
+	assert.Equal(t, NewURI("file:/a.test#//@books.0"), GetURI(m.bookObject))
 }
 
 func TestGetEObjectFromRoot(t *testing.T) {

--- a/ecore/eallcontents_test.go
+++ b/ecore/eallcontents_test.go
@@ -168,7 +168,7 @@ type eAllContentsModel struct {
 func loadEAllContentsModel(t *testing.T, ePackage EPackage) *eAllContentsModel {
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/eallcontents.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/eallcontents.xml"))
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))

--- a/ecore/eannotation_impl_test.go
+++ b/ecore/eannotation_impl_test.go
@@ -41,6 +41,7 @@ func TestEAnnotationFeatureCount(t *testing.T) {
 func TestEAnnotationContentsGet(t *testing.T) {
 	o := newEAnnotationImpl()
 	assert.NotNil(t, o.GetContents())
+	assert.Panics(t, func() { _ = o.GetContents().Get(0).(EObject) })
 }
 
 func TestEAnnotationDetailsGet(t *testing.T) {
@@ -123,6 +124,7 @@ func TestEAnnotationEModelElementBasicSet(t *testing.T) {
 func TestEAnnotationReferencesGet(t *testing.T) {
 	o := newEAnnotationImpl()
 	assert.NotNil(t, o.GetReferences())
+	assert.Panics(t, func() { _ = o.GetReferences().Get(0).(EObject) })
 }
 
 func TestEAnnotationSourceGet(t *testing.T) {

--- a/ecore/eclass_impl_test.go
+++ b/ecore/eclass_impl_test.go
@@ -41,46 +41,55 @@ func TestEClassFeatureCount(t *testing.T) {
 func TestEClassEAllAttributesGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEAllAttributes())
+	assert.Panics(t, func() { _ = o.GetEAllAttributes().Get(0).(EAttribute) })
 }
 
 func TestEClassEAllContainmentsGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEAllContainments())
+	assert.Panics(t, func() { _ = o.GetEAllContainments().Get(0).(EReference) })
 }
 
 func TestEClassEAllOperationsGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEAllOperations())
+	assert.Panics(t, func() { _ = o.GetEAllOperations().Get(0).(EOperation) })
 }
 
 func TestEClassEAllReferencesGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEAllReferences())
+	assert.Panics(t, func() { _ = o.GetEAllReferences().Get(0).(EReference) })
 }
 
 func TestEClassEAllStructuralFeaturesGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEAllStructuralFeatures())
+	assert.Panics(t, func() { _ = o.GetEAllStructuralFeatures().Get(0).(EStructuralFeature) })
 }
 
 func TestEClassEAllSuperTypesGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEAllSuperTypes())
+	assert.Panics(t, func() { _ = o.GetEAllSuperTypes().Get(0).(EClass) })
 }
 
 func TestEClassEAttributesGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEAttributes())
+	assert.Panics(t, func() { _ = o.GetEAttributes().Get(0).(EAttribute) })
 }
 
 func TestEClassEContainmentFeaturesGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEContainmentFeatures())
+	assert.Panics(t, func() { _ = o.GetEContainmentFeatures().Get(0).(EStructuralFeature) })
 }
 
 func TestEClassECrossReferenceFeaturesGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetECrossReferenceFeatures())
+	assert.Panics(t, func() { _ = o.GetECrossReferenceFeatures().Get(0).(EStructuralFeature) })
 }
 
 func TestEClassEIDAttributeGet(t *testing.T) {
@@ -91,21 +100,25 @@ func TestEClassEIDAttributeGet(t *testing.T) {
 func TestEClassEOperationsGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEOperations())
+	assert.Panics(t, func() { _ = o.GetEOperations().Get(0).(EOperation) })
 }
 
 func TestEClassEReferencesGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEReferences())
+	assert.Panics(t, func() { _ = o.GetEReferences().Get(0).(EReference) })
 }
 
 func TestEClassEStructuralFeaturesGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetEStructuralFeatures())
+	assert.Panics(t, func() { _ = o.GetEStructuralFeatures().Get(0).(EStructuralFeature) })
 }
 
 func TestEClassESuperTypesGet(t *testing.T) {
 	o := newEClassImpl()
 	assert.NotNil(t, o.GetESuperTypes())
+	assert.Panics(t, func() { _ = o.GetESuperTypes().Get(0).(EClass) })
 }
 
 func TestEClassAbstractGet(t *testing.T) {

--- a/ecore/econtentadapter_test.go
+++ b/ecore/econtentadapter_test.go
@@ -533,7 +533,7 @@ func BenchmarkEContentAdapterWithBigModel(b *testing.B) {
 
 		// load resource
 		xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-		eResource := xmlProcessor.Load(&URI{Path: "testdata/library.complex.big.xml"})
+		eResource := xmlProcessor.Load(NewURI("testdata/library.complex.big.xml"))
 		require.NotNil(b, eResource)
 		assert.True(b, eResource.IsLoaded())
 		assert.True(b, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -555,7 +555,7 @@ func BenchmarkEContentAdapterWithTreeModel(b *testing.B) {
 
 		// load resource
 		xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-		eResource := xmlProcessor.Load(&URI{Path: "testdata/tree.xml"})
+		eResource := xmlProcessor.Load(NewURI("testdata/tree.xml"))
 		require.NotNil(b, eResource)
 		assert.True(b, eResource.IsLoaded())
 		assert.True(b, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))

--- a/ecore/ecoreutils.go
+++ b/ecore/ecoreutils.go
@@ -51,15 +51,13 @@ func GetURI(eObject EObject) *URI {
 	} else {
 		resource := eObject.EResource()
 		if resource != nil {
-			uri := resource.GetURI().Copy()
-			uri.fragment = resource.GetURIFragment(eObject)
-			return uri
+			return NewURIBuilder(resource.GetURI()).SetFragment(resource.GetURIFragment(eObject)).URI()
 		} else {
 			id := GetEObjectID(eObject)
 			if len(id) == 0 {
-				return BuildURI(Fragment("//" + getRelativeURIFragmentPath(nil, eObject, false)))
+				return NewURIBuilder(nil).SetFragment("//" + getRelativeURIFragmentPath(nil, eObject, false)).URI()
 			} else {
-				return BuildURI(Fragment(id))
+				return NewURIBuilder(nil).SetFragment(id).URI()
 			}
 		}
 	}

--- a/ecore/ecoreutils.go
+++ b/ecore/ecoreutils.go
@@ -52,14 +52,14 @@ func GetURI(eObject EObject) *URI {
 		resource := eObject.EResource()
 		if resource != nil {
 			uri := resource.GetURI().Copy()
-			uri.Fragment = resource.GetURIFragment(eObject)
+			uri.fragment = resource.GetURIFragment(eObject)
 			return uri
 		} else {
 			id := GetEObjectID(eObject)
 			if len(id) == 0 {
-				return &URI{Fragment: "//" + getRelativeURIFragmentPath(nil, eObject, false)}
+				return BuildURI(Fragment("//" + getRelativeURIFragmentPath(nil, eObject, false)))
 			} else {
-				return &URI{Fragment: id}
+				return BuildURI(Fragment(id))
 			}
 		}
 	}
@@ -136,7 +136,7 @@ func ResolveInResourceSet(proxy EObject, resourceSet EResourceSet) EObject {
 			if ePackage != nil {
 				eResource := ePackage.EResource()
 				if eResource != nil {
-					resolved = eResource.GetEObject(proxyURI.Fragment)
+					resolved = eResource.GetEObject(proxyURI.fragment)
 				}
 			}
 		}

--- a/ecore/ecoreutils_test.go
+++ b/ecore/ecoreutils_test.go
@@ -118,17 +118,17 @@ func TestEcoreUtilsEqualsProxy(t *testing.T) {
 	obj1 := &MockEObjectInternal{}
 	obj2 := &MockEObjectInternal{}
 	obj1.On("EIsProxy").Once().Return(true)
-	obj1.On("EProxyURI").Once().Return(&URI{Path: "test"})
-	obj2.On("EProxyURI").Once().Return(&URI{Path: "test"})
+	obj1.On("EProxyURI").Once().Return(NewURI("test"))
+	obj2.On("EProxyURI").Once().Return(NewURI("test"))
 	assert.True(t, Equals(obj1, obj2))
 
 	obj1.On("EIsProxy").Once().Return(true)
-	obj1.On("EProxyURI").Once().Return(&URI{Path: "test1"})
-	obj2.On("EProxyURI").Once().Return(&URI{Path: "test2"})
+	obj1.On("EProxyURI").Once().Return(NewURI("test1"))
+	obj2.On("EProxyURI").Once().Return(NewURI("test2"))
 	assert.False(t, Equals(obj1, obj2))
 
 	obj1.On("EIsProxy").Once().Return(true)
-	obj1.On("EProxyURI").Once().Return(&URI{Path: "test"})
+	obj1.On("EProxyURI").Once().Return(NewURI("test"))
 	obj2.On("EProxyURI").Once().Return(nil)
 	assert.False(t, Equals(obj1, obj2))
 
@@ -310,7 +310,7 @@ func TestEcoreUtilsCopyProxy(t *testing.T) {
 
 	// the model
 	eObject := eFactory.Create(eClass)
-	eObject.(EObjectInternal).ESetProxyURI(&URI{Path: "testPath"})
+	eObject.(EObjectInternal).ESetProxyURI(NewURI("testPath"))
 
 	eObjectCopy := Copy(eObject)
 	assert.True(t, Equals(eObject, eObjectCopy))

--- a/ecore/eenum_impl_test.go
+++ b/ecore/eenum_impl_test.go
@@ -41,6 +41,7 @@ func TestEEnumFeatureCount(t *testing.T) {
 func TestEEnumELiteralsGet(t *testing.T) {
 	o := newEEnumImpl()
 	assert.NotNil(t, o.GetELiterals())
+	assert.Panics(t, func() { _ = o.GetELiterals().Get(0).(EEnumLiteral) })
 }
 
 func TestEEnumGetEEnumLiteralByLiteralOperation(t *testing.T) {

--- a/ecore/egenerictype_impl_test.go
+++ b/ecore/egenerictype_impl_test.go
@@ -188,6 +188,7 @@ func TestEGenericTypeERawTypeGet(t *testing.T) {
 func TestEGenericTypeETypeArgumentsGet(t *testing.T) {
 	o := newEGenericTypeImpl()
 	assert.NotNil(t, o.GetETypeArguments())
+	assert.Panics(t, func() { _ = o.GetETypeArguments().Get(0).(EGenericType) })
 }
 
 func TestEGenericTypeETypeParameterGet(t *testing.T) {

--- a/ecore/emodelelement_impl_test.go
+++ b/ecore/emodelelement_impl_test.go
@@ -41,6 +41,7 @@ func TestEModelElementFeatureCount(t *testing.T) {
 func TestEModelElementEAnnotationsGet(t *testing.T) {
 	o := newEModelElementImpl()
 	assert.NotNil(t, o.GetEAnnotations())
+	assert.Panics(t, func() { _ = o.GetEAnnotations().Get(0).(EAnnotation) })
 }
 
 func TestEModelElementGetEAnnotationOperation(t *testing.T) {

--- a/ecore/eoperation_impl_test.go
+++ b/ecore/eoperation_impl_test.go
@@ -55,6 +55,7 @@ func TestEOperationEContainingClassGet(t *testing.T) {
 func TestEOperationEExceptionsGet(t *testing.T) {
 	o := newEOperationImpl()
 	assert.NotNil(t, o.GetEExceptions())
+	assert.Panics(t, func() { _ = o.GetEExceptions().Get(0).(EClassifier) })
 }
 
 func TestEOperationEExceptionsUnSet(t *testing.T) {
@@ -67,6 +68,7 @@ func TestEOperationEExceptionsUnSet(t *testing.T) {
 func TestEOperationEParametersGet(t *testing.T) {
 	o := newEOperationImpl()
 	assert.NotNil(t, o.GetEParameters())
+	assert.Panics(t, func() { _ = o.GetEParameters().Get(0).(EParameter) })
 }
 
 func TestEOperationOperationIDGet(t *testing.T) {

--- a/ecore/epackage_impl_test.go
+++ b/ecore/epackage_impl_test.go
@@ -41,6 +41,7 @@ func TestEPackageFeatureCount(t *testing.T) {
 func TestEPackageEClassifiersGet(t *testing.T) {
 	o := newEPackageImpl()
 	assert.NotNil(t, o.GetEClassifiers())
+	assert.Panics(t, func() { _ = o.GetEClassifiers().Get(0).(EClassifier) })
 }
 
 func TestEPackageEFactoryInstanceGet(t *testing.T) {
@@ -100,6 +101,7 @@ func TestEPackageEFactoryInstanceBasicSet(t *testing.T) {
 func TestEPackageESubPackagesGet(t *testing.T) {
 	o := newEPackageImpl()
 	assert.NotNil(t, o.GetESubPackages())
+	assert.Panics(t, func() { _ = o.GetESubPackages().Get(0).(EPackage) })
 }
 
 func TestEPackageESuperPackageGet(t *testing.T) {

--- a/ecore/ereference_impl_test.go
+++ b/ecore/ereference_impl_test.go
@@ -41,6 +41,7 @@ func TestEReferenceFeatureCount(t *testing.T) {
 func TestEReferenceEKeysGet(t *testing.T) {
 	o := newEReferenceImpl()
 	assert.NotNil(t, o.GetEKeys())
+	assert.Panics(t, func() { _ = o.GetEKeys().Get(0).(EAttribute) })
 }
 
 func TestEReferenceEOppositeGet(t *testing.T) {

--- a/ecore/eresource.go
+++ b/ecore/eresource.go
@@ -18,7 +18,7 @@ const (
 	RESOURCE__WARNINGS = 6
 )
 
-//EResource ...
+// EResource ...
 type EResource interface {
 	ENotifier
 

--- a/ecore/eresource_impl.go
+++ b/ecore/eresource_impl.go
@@ -157,7 +157,7 @@ func (rd *resourceDiagnostics) GetFeatureID() int {
 	return rd.featureID
 }
 
-//EResource ...
+// EResource ...
 type EResourceImpl struct {
 	ENotifierImpl
 	resourceSet     EResourceSet

--- a/ecore/eresource_impl_test.go
+++ b/ecore/eresource_impl_test.go
@@ -44,7 +44,7 @@ func TestResourceContents(t *testing.T) {
 
 func TestResourceLoadInvalid(t *testing.T) {
 	r := NewEResourceImpl()
-	r.SetURI(&URI{Path: "testdata/invalid.xml"})
+	r.SetURI(NewURI("testdata/invalid.xml"))
 	r.Load()
 	assert.False(t, r.IsLoaded())
 	assert.False(t, r.GetErrors().Empty())

--- a/ecore/eresourcecodecregistry_impl.go
+++ b/ecore/eresourcecodecregistry_impl.go
@@ -33,13 +33,13 @@ func NewEResourceCodecRegistryImplWithDelegate(delegate EResourceCodecRegistry) 
 }
 
 func (r *EResourceCodecRegistryImpl) GetCodec(uri *URI) EResourceCodec {
-	if factory, ok := r.protocolToCodec[uri.Scheme]; ok {
+	if factory, ok := r.protocolToCodec[uri.scheme]; ok {
 		return factory
 	}
-
-	ndx := strings.LastIndex(uri.Path, ".")
+	p := uri.Path()
+	ndx := strings.LastIndex(p, ".")
 	if ndx != -1 {
-		extension := uri.Path[ndx+1:]
+		extension := p[ndx+1:]
 		if factory, ok := r.extensionToCodec[extension]; ok {
 			return factory
 		}

--- a/ecore/eresourcecodecregistry_impl_test.go
+++ b/ecore/eresourcecodecregistry_impl_test.go
@@ -21,8 +21,8 @@ func TestEResourceCodecRegistryGetCodecProtocol(t *testing.T) {
 	rfr := NewEResourceCodecRegistryImpl()
 	rfr.GetProtocolToCodecMap()["test"] = mockCodec
 
-	assert.Equal(t, mockCodec, rfr.GetCodec(&URI{Scheme: "test", Path: "//file.t"}))
-	assert.Nil(t, rfr.GetCodec(&URI{Scheme: "file", Path: "//file.t"}))
+	assert.Equal(t, mockCodec, rfr.GetCodec(&URI{scheme: "test", Path: "//file.t"}))
+	assert.Nil(t, rfr.GetCodec(&URI{scheme: "file", Path: "//file.t"}))
 }
 
 func TestEResourceCodecRegistryGetCodecExtension(t *testing.T) {
@@ -31,6 +31,6 @@ func TestEResourceCodecRegistryGetCodecExtension(t *testing.T) {
 	rfr := NewEResourceCodecRegistryImpl()
 	rfr.GetExtensionToCodecMap()["test"] = mockCodec
 
-	assert.Equal(t, mockCodec, rfr.GetCodec(&URI{Scheme: "file", Path: "//file.test"}))
-	assert.Nil(t, rfr.GetCodec(&URI{Scheme: "file", Path: "//file.t"}))
+	assert.Equal(t, mockCodec, rfr.GetCodec(&URI{scheme: "file", Path: "//file.test"}))
+	assert.Nil(t, rfr.GetCodec(&URI{scheme: "file", Path: "//file.t"}))
 }

--- a/ecore/eresourcecodecregistry_impl_test.go
+++ b/ecore/eresourcecodecregistry_impl_test.go
@@ -21,8 +21,8 @@ func TestEResourceCodecRegistryGetCodecProtocol(t *testing.T) {
 	rfr := NewEResourceCodecRegistryImpl()
 	rfr.GetProtocolToCodecMap()["test"] = mockCodec
 
-	assert.Equal(t, mockCodec, rfr.GetCodec(&URI{scheme: "test", Path: "//file.t"}))
-	assert.Nil(t, rfr.GetCodec(&URI{scheme: "file", Path: "//file.t"}))
+	assert.Equal(t, mockCodec, rfr.GetCodec(NewURI("test:///file.t")))
+	assert.Nil(t, rfr.GetCodec(NewURI("file:///file.t")))
 }
 
 func TestEResourceCodecRegistryGetCodecExtension(t *testing.T) {
@@ -31,6 +31,6 @@ func TestEResourceCodecRegistryGetCodecExtension(t *testing.T) {
 	rfr := NewEResourceCodecRegistryImpl()
 	rfr.GetExtensionToCodecMap()["test"] = mockCodec
 
-	assert.Equal(t, mockCodec, rfr.GetCodec(&URI{scheme: "file", Path: "//file.test"}))
-	assert.Nil(t, rfr.GetCodec(&URI{scheme: "file", Path: "//file.t"}))
+	assert.Equal(t, mockCodec, rfr.GetCodec(NewURI("test:///file.test")))
+	assert.Nil(t, rfr.GetCodec(NewURI("file:///file.t")))
 }

--- a/ecore/eresourcecodecregistry_test.go
+++ b/ecore/eresourcecodecregistry_test.go
@@ -25,6 +25,6 @@ func TestResoureCodecRegistrySingleton(t *testing.T) {
 
 func TestResoureCodecRegistrySingletonGetCodec(t *testing.T) {
 	r := GetResourceCodecRegistry()
-	assert.NotNil(t, r.GetCodec(&URI{Path: "*.xml"}))
-	assert.NotNil(t, r.GetCodec(&URI{Path: "*.ecore"}))
+	assert.NotNil(t, r.GetCodec(NewURI("*.xml")))
+	assert.NotNil(t, r.GetCodec(NewURI("*.ecore")))
 }

--- a/ecore/eresourceset_impl.go
+++ b/ecore/eresourceset_impl.go
@@ -128,7 +128,7 @@ func (r *EResourceSetImpl) GetEObject(uri *URI, loadOnDemand bool) EObject {
 	trim := uri.TrimFragment()
 	resource := r.GetResource(trim, loadOnDemand)
 	if resource != nil {
-		return resource.GetEObject(uri.Fragment)
+		return resource.GetEObject(uri.Fragment())
 	}
 	return nil
 }

--- a/ecore/eresourceset_impl.go
+++ b/ecore/eresourceset_impl.go
@@ -92,7 +92,7 @@ func (r *EResourceSetImpl) GetResource(uri *URI, loadOnDemand bool) EResource {
 	for it := r.resources.Iterator(); it.HasNext(); {
 		resource := it.Next().(EResource)
 		resourceURI := r.GetURIConverter().Normalize(resource.GetURI())
-		if *resourceURI == *normalizedURI {
+		if resourceURI.Equals(normalizedURI) {
 			if loadOnDemand && !resource.IsLoaded() {
 				resource.Load()
 			}

--- a/ecore/eresourceset_impl.go
+++ b/ecore/eresourceset_impl.go
@@ -36,7 +36,7 @@ func (l *resourcesList) inverseRemove(object interface{}, notifications ENotific
 	return n
 }
 
-//EResourceSetImpl ...
+// EResourceSetImpl ...
 type EResourceSetImpl struct {
 	ENotifierImpl
 	resources             EList

--- a/ecore/eresourseset.go
+++ b/ecore/eresourseset.go
@@ -13,7 +13,7 @@ const (
 	RESOURCE_SET__RESOURCES = 0
 )
 
-//EResourceSet ...
+// EResourceSet ...
 type EResourceSet interface {
 	ENotifier
 

--- a/ecore/etypeparameter_impl_test.go
+++ b/ecore/etypeparameter_impl_test.go
@@ -41,6 +41,7 @@ func TestETypeParameterFeatureCount(t *testing.T) {
 func TestETypeParameterEBoundsGet(t *testing.T) {
 	o := newETypeParameterImpl()
 	assert.NotNil(t, o.GetEBounds())
+	assert.Panics(t, func() { _ = o.GetEBounds().Get(0).(EGenericType) })
 }
 
 func TestETypeParameterEGetFromID(t *testing.T) {

--- a/ecore/euriconverter.go
+++ b/ecore/euriconverter.go
@@ -4,7 +4,7 @@ import (
 	"io"
 )
 
-//URIConverter ...
+// URIConverter ...
 type EURIConverter interface {
 	CreateReader(uri *URI) (io.ReadCloser, error)
 

--- a/ecore/euriconverter_impl.go
+++ b/ecore/euriconverter_impl.go
@@ -41,7 +41,7 @@ func (r *EURIConverterImpl) GetURIMap() map[URI]URI {
 
 func (r *EURIConverterImpl) Normalize(uri *URI) *URI {
 	normalized := r.getURIFromMap(uri)
-	if normalized == uri || *normalized == *uri {
+	if uri.Equals(normalized) {
 		return normalized
 	}
 	return r.Normalize(normalized)

--- a/ecore/euriconverter_impl_test.go
+++ b/ecore/euriconverter_impl_test.go
@@ -57,7 +57,7 @@ func TestEURIConverterCreateReaderWithMapping(t *testing.T) {
 	mockHandler := &MockEURIHandler{}
 	c := NewEURIConverterImpl()
 	c.uriHandlers = NewImmutableEList([]interface{}{mockHandler})
-	c.uriMap = map[URI]URI{{Scheme: "test"}: {Scheme: "file"}}
+	c.uriMap = map[URI]URI{{scheme: "test"}: {scheme: "file"}}
 	uri, _ := ParseURI("test:///file.ext")
 	normalized, _ := ParseURI("file:///file.ext")
 	mockFile, _ := os.Open(normalized.String())
@@ -113,15 +113,15 @@ func TestEURIConverterNormalize(t *testing.T) {
 	}
 	{
 		c := NewEURIConverterImpl()
-		c.GetURIMap()[URI{Scheme: "test"}] = URI{Scheme: "test2"}
-		assert.Equal(t, &URI{Scheme: "test2", Path: "file.ext"}, c.Normalize(&URI{Scheme: "test", Path: "file.ext"}))
-		assert.Equal(t, &URI{Scheme: "bla", Path: "file.ext"}, c.Normalize(&URI{Scheme: "bla", Path: "file.ext"}))
+		c.GetURIMap()[URI{scheme: "test"}] = URI{scheme: "test2"}
+		assert.Equal(t, &URI{scheme: "test2", Path: "file.ext"}, c.Normalize(&URI{scheme: "test", Path: "file.ext"}))
+		assert.Equal(t, &URI{scheme: "bla", Path: "file.ext"}, c.Normalize(&URI{scheme: "bla", Path: "file.ext"}))
 	}
 	{
 		c := NewEURIConverterImpl()
-		c.GetURIMap()[URI{Scheme: "test"}] = URI{Scheme: "test2"}
-		c.GetURIMap()[URI{Scheme: "test2"}] = URI{Scheme: "test3"}
-		assert.Equal(t, &URI{Scheme: "test3", Path: "file.ext"}, c.Normalize(&URI{Scheme: "test", Path: "file.ext"}))
+		c.GetURIMap()[URI{scheme: "test"}] = URI{scheme: "test2"}
+		c.GetURIMap()[URI{scheme: "test2"}] = URI{scheme: "test3"}
+		assert.Equal(t, &URI{scheme: "test3", Path: "file.ext"}, c.Normalize(&URI{scheme: "test", Path: "file.ext"}))
 	}
 }
 

--- a/ecore/euriconverter_mock_test.go
+++ b/ecore/euriconverter_mock_test.go
@@ -65,7 +65,7 @@ func TestMockEURIConverterCreateWriter(t *testing.T) {
 
 func TestMockEURIConverterGetURIMap(t *testing.T) {
 	h := &MockEURIConverter{}
-	m := map[URI]URI{{Path: "toto"}: {Path: "tata"}}
+	m := map[URI]URI{*NewURI("toto"): *NewURI("tata")}
 	h.On("GetURIMap").Return(m).Once()
 	h.On("GetURIMap").Return(func() map[URI]URI {
 		return m

--- a/ecore/eurihandler.go
+++ b/ecore/eurihandler.go
@@ -4,7 +4,7 @@ import (
 	"io"
 )
 
-//URIHandler ...
+// URIHandler ...
 type EURIHandler interface {
 	CanHandle(uri *URI) bool
 

--- a/ecore/fileurihandler.go
+++ b/ecore/fileurihandler.go
@@ -10,7 +10,7 @@ type FileURIHandler struct {
 }
 
 func (fuh *FileURIHandler) CanHandle(uri *URI) bool {
-	return uri.Scheme == "file" || (!uri.IsAbsolute() && len(uri.Query) == 0)
+	return uri.scheme == "file" || (!uri.IsAbsolute() && len(uri.query) == 0)
 }
 
 func (fuh *FileURIHandler) CreateReader(uri *URI) (io.ReadCloser, error) {

--- a/ecore/fileurihandler.go
+++ b/ecore/fileurihandler.go
@@ -14,7 +14,7 @@ func (fuh *FileURIHandler) CanHandle(uri *URI) bool {
 }
 
 func (fuh *FileURIHandler) CreateReader(uri *URI) (io.ReadCloser, error) {
-	fileName := uri.Path
+	fileName := uri.Path()
 	if fileName[0] == '/' {
 		fileName = fileName[1:]
 	}
@@ -26,7 +26,7 @@ func (fuh *FileURIHandler) CreateReader(uri *URI) (io.ReadCloser, error) {
 }
 
 func (fuh *FileURIHandler) CreateWriter(uri *URI) (io.WriteCloser, error) {
-	fileName := uri.Path
+	fileName := uri.Path()
 	if fileName[0] == '/' {
 		fileName = fileName[1:]
 	}

--- a/ecore/fileurihandler.go
+++ b/ecore/fileurihandler.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-//URIHandler ...
+// URIHandler ...
 type FileURIHandler struct {
 }
 

--- a/ecore/memoryurihandler.go
+++ b/ecore/memoryurihandler.go
@@ -8,7 +8,7 @@ type MemoryURIHandler struct {
 }
 
 func (muh *MemoryURIHandler) CanHandle(uri *URI) bool {
-	return uri.Scheme == "memory"
+	return uri.scheme == "memory"
 }
 
 func (muh *MemoryURIHandler) CreateReader(uri *URI) (io.ReadCloser, error) {

--- a/ecore/memoryurihandler_test.go
+++ b/ecore/memoryurihandler_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestMemoryURIHandler_CanHandle(t *testing.T) {
 	m := &MemoryURIHandler{}
-	assert.True(t, m.CanHandle(&URI{Scheme: "memory"}))
-	assert.False(t, m.CanHandle(&URI{Scheme: "file"}))
+	assert.True(t, m.CanHandle(&URI{scheme: "memory"}))
+	assert.False(t, m.CanHandle(&URI{scheme: "file"}))
 }
 
 func TestMemoryURIHandler_CreateReader(t *testing.T) {

--- a/ecore/uri.go
+++ b/ecore/uri.go
@@ -90,8 +90,18 @@ func (b *URIBuilder) SetQuery(query string) *URIBuilder {
 	return b
 }
 
+func (b *URIBuilder) ClearQuery() *URIBuilder {
+	b.query = ""
+	return b
+}
+
 func (b *URIBuilder) SetFragment(fragment string) *URIBuilder {
 	b.fragment = fragment
+	return b
+}
+
+func (b *URIBuilder) ClearFragment() *URIBuilder {
+	b.fragment = ""
 	return b
 }
 

--- a/ecore/uri_test.go
+++ b/ecore/uri_test.go
@@ -18,15 +18,15 @@ import (
 )
 
 func TestURI_Constructor(t *testing.T) {
-	assert.Equal(t, &URI{Scheme: "http"}, NewURI("http://"))
-	assert.Equal(t, &URI{Scheme: "http", Host: "host"}, NewURI("http://host"))
-	assert.Equal(t, &URI{Scheme: "http", Host: "host", Port: 10020}, NewURI("http://host:10020"))
-	assert.Equal(t, &URI{Scheme: "http", Host: "host", Port: 10020, Path: "/path/path2"}, NewURI("http://host:10020/path/path2"))
-	assert.Equal(t, &URI{Scheme: "http", Host: "host", Port: 10020, Path: "/path/path2", Query: "key1=foo&key2=&key3&=bar&=bar="}, NewURI("http://host:10020/path/path2?key1=foo&key2=&key3&=bar&=bar="))
-	assert.Equal(t, &URI{Scheme: "http", Host: "host", Port: 10020, Path: "/path/path2", Fragment: "fragment"}, NewURI("http://host:10020/path/path2#fragment"))
-	assert.Equal(t, &URI{Scheme: "file", Host: "file.txt", Query: "query", Fragment: "fragment"}, NewURI("file://file.txt?query#fragment"))
-	assert.Equal(t, &URI{Scheme: "file", Path: "/file.txt", Query: "query", Fragment: "fragment"}, NewURI("file:///file.txt?query#fragment"))
-	assert.Equal(t, &URI{Fragment: "fragment"}, NewURI("//#fragment"))
+	assert.Equal(t, &URI{scheme: "http"}, NewURI("http://"))
+	assert.Equal(t, &URI{scheme: "http", host: "host"}, NewURI("http://host"))
+	assert.Equal(t, &URI{scheme: "http", host: "host", port: 10020}, NewURI("http://host:10020"))
+	assert.Equal(t, &URI{scheme: "http", host: "host", port: 10020, Path: "/path/path2"}, NewURI("http://host:10020/path/path2"))
+	assert.Equal(t, &URI{scheme: "http", host: "host", port: 10020, Path: "/path/path2", query: "key1=foo&key2=&key3&=bar&=bar="}, NewURI("http://host:10020/path/path2?key1=foo&key2=&key3&=bar&=bar="))
+	assert.Equal(t, &URI{scheme: "http", host: "host", port: 10020, Path: "/path/path2", fragment: "fragment"}, NewURI("http://host:10020/path/path2#fragment"))
+	assert.Equal(t, &URI{scheme: "file", host: "file.txt", query: "query", fragment: "fragment"}, NewURI("file://file.txt?query#fragment"))
+	assert.Equal(t, &URI{scheme: "file", Path: "/file.txt", query: "query", fragment: "fragment"}, NewURI("file:///file.txt?query#fragment"))
+	assert.Equal(t, &URI{fragment: "fragment"}, NewURI("//#fragment"))
 	assert.Equal(t, &URI{Path: "path"}, NewURI("path"))
 	assert.Equal(t, &URI{Path: "./path"}, NewURI("./path"))
 }
@@ -55,21 +55,21 @@ func TestURI_IsEmpty(t *testing.T) {
 		assert.True(t, u.IsEmpty())
 	}
 	{
-		u := &URI{Scheme: "t"}
+		u := &URI{scheme: "t"}
 		assert.False(t, u.IsEmpty())
 	}
 }
 
 func TestURI_Copy(t *testing.T) {
 	uri := &URI{
-		Scheme:   "scheme",
-		Username: "username",
-		Password: "password",
-		Host:     "host",
-		Port:     10,
+		scheme:   "scheme",
+		username: "username",
+		password: "password",
+		host:     "host",
+		port:     10,
 		Path:     "path",
-		Query:    "query",
-		Fragment: "fragment",
+		query:    "query",
+		fragment: "fragment",
 	}
 	assert.Equal(t, uri, uri.Copy())
 }
@@ -102,9 +102,9 @@ func TestURI_ReplacePrefix(t *testing.T) {
 	assert.Nil(t, NewURI("http://host").ReplacePrefix(NewURI("http://host2/path"), nil))
 	assert.Nil(t, NewURI("test/toto").ReplacePrefix(NewURI("info"), nil))
 	{
-		uri := NewURI("test:///toto").ReplacePrefix(&URI{Scheme: "test"}, &URI{Scheme: "file"})
+		uri := NewURI("test:///toto").ReplacePrefix(&URI{scheme: "test"}, &URI{scheme: "file"})
 		require.NotNil(t, uri)
-		assert.Equal(t, "file", uri.Scheme)
+		assert.Equal(t, "file", uri.scheme)
 	}
 	{
 		uri := NewURI("").ReplacePrefix(&URI{}, &URI{Path: "file"})
@@ -132,15 +132,15 @@ func TestCreateFileURI(t *testing.T) {
 	assert.Equal(t, &URI{}, CreateFileURI(""))
 	if runtime.GOOS == "windows" {
 		assert.Equal(t, &URI{Path: "test/toto"}, CreateFileURI("test\\toto"))
-		assert.Equal(t, &URI{Scheme: "file", Path: "D:/test/toto"}, CreateFileURI("D:\\test\\toto"))
+		assert.Equal(t, &URI{scheme: "file", Path: "D:/test/toto"}, CreateFileURI("D:\\test\\toto"))
 	} else {
 		assert.Equal(t, &URI{Path: "test/toto"}, CreateFileURI("test/toto"))
-		assert.Equal(t, &URI{Scheme: "file", Path: "/test/toto"}, CreateFileURI("/test/toto"))
+		assert.Equal(t, &URI{scheme: "file", Path: "/test/toto"}, CreateFileURI("/test/toto"))
 	}
 }
 
 func TestCreateMemoryURI(t *testing.T) {
 	assert.Nil(t, CreateMemoryURI(""))
-	assert.Equal(t, &URI{Scheme: "memory", Path: "path"}, CreateMemoryURI("path"))
+	assert.Equal(t, &URI{scheme: "memory", Path: "path"}, CreateMemoryURI("path"))
 	assert.Equal(t, "memory:path", CreateMemoryURI("path").String())
 }

--- a/ecore/uri_test.go
+++ b/ecore/uri_test.go
@@ -144,3 +144,11 @@ func TestCreateMemoryURI(t *testing.T) {
 	assert.Equal(t, NewURI("memory:path"), CreateMemoryURI("path"))
 	assert.Equal(t, "memory:path", CreateMemoryURI("path").String())
 }
+
+func TestURI_Authority(t *testing.T) {
+	assert.Equal(t, "", NewURI("http:///file.text").Authority())
+	assert.Equal(t, "", NewURI("http:/file.text").Authority())
+	assert.Equal(t, "host", NewURI("http://host/file.text").Authority())
+	assert.Equal(t, "host:10", NewURI("http://host:10/file.text").Authority())
+	assert.Equal(t, "userinfo@host:10", NewURI("http://userinfo@host:10/file.text").Authority())
+}

--- a/ecore/uri_test.go
+++ b/ecore/uri_test.go
@@ -135,7 +135,7 @@ func TestCreateFileURI(t *testing.T) {
 		assert.Equal(t, NewURI("file:D:/test/toto"), CreateFileURI("D:\\test\\toto"))
 	} else {
 		assert.Equal(t, NewURI("test/toto"), CreateFileURI("test/toto"))
-		assert.Equal(t, NewURI("file:test/toto"), CreateFileURI("/test/toto"))
+		assert.Equal(t, NewURI("file:/test/toto"), CreateFileURI("/test/toto"))
 	}
 }
 

--- a/ecore/xmidecoder_test.go
+++ b/ecore/xmidecoder_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestXMIDecoderLibrarySimple(t *testing.T) {
 	xmiProcessor := NewXMIProcessor()
-	resource := xmiProcessor.Load(&URI{Path: "testdata/library.simple.ecore"})
+	resource := xmiProcessor.Load(NewURI("testdata/library.simple.ecore"))
 	require.NotNil(t, resource)
 	assert.True(t, resource.IsLoaded())
 	assert.True(t, resource.GetErrors().Empty(), diagnosticError(resource.GetErrors()))
@@ -86,7 +86,7 @@ func TestXMIDecoderLibrarySimple(t *testing.T) {
 
 func TestXMIDecoderLibraryNoRoot(t *testing.T) {
 	xmiProcessor := NewXMIProcessor()
-	resource := xmiProcessor.Load(&URI{Path: "testdata/library.noroot.ecore"})
+	resource := xmiProcessor.Load(NewURI("testdata/library.noroot.ecore"))
 	require.NotNil(t, resource)
 	assert.True(t, resource.IsLoaded())
 	assert.True(t, resource.GetErrors().Empty(), diagnosticError(resource.GetErrors()))
@@ -120,7 +120,7 @@ func TestXMIDecoderLibraryNoRoot(t *testing.T) {
 
 func TestXMIDecoderLibraryComplex(t *testing.T) {
 	xmiProcessor := NewXMIProcessor()
-	resource := xmiProcessor.Load(&URI{Path: "testdata/library.complex.ecore"})
+	resource := xmiProcessor.Load(NewURI("testdata/library.complex.ecore"))
 	require.NotNil(t, resource)
 	assert.True(t, resource.IsLoaded())
 	assert.True(t, resource.GetErrors().Empty(), diagnosticError(resource.GetErrors()))

--- a/ecore/xmiencoder_test.go
+++ b/ecore/xmiencoder_test.go
@@ -21,7 +21,7 @@ import (
 func TestXMIEncoderLibrarySimple(t *testing.T) {
 	// load/save
 	xmiProcessor := NewXMIProcessor()
-	resource := xmiProcessor.Load(&URI{Path: "testdata/library.simple.ecore"})
+	resource := xmiProcessor.Load(NewURI("testdata/library.simple.ecore"))
 	require.NotNil(t, resource)
 	result := xmiProcessor.SaveToString(resource, nil)
 	// check
@@ -33,7 +33,7 @@ func TestXMIEncoderLibrarySimple(t *testing.T) {
 func TestXMIEncoderLibraryNoRoot(t *testing.T) {
 	// load/save
 	xmiProcessor := NewXMIProcessor()
-	resource := xmiProcessor.Load(&URI{Path: "testdata/library.noroot.ecore"})
+	resource := xmiProcessor.Load(NewURI("testdata/library.noroot.ecore"))
 	require.NotNil(t, resource)
 	result := xmiProcessor.SaveToString(resource, nil)
 	// check
@@ -45,7 +45,7 @@ func TestXMIEncoderLibraryNoRoot(t *testing.T) {
 func TestXMIEncoderLibraryComplex(t *testing.T) {
 	// load/save
 	xmiProcessor := NewXMIProcessor()
-	resource := xmiProcessor.Load(&URI{Path: "testdata/library.complex.ecore"})
+	resource := xmiProcessor.Load(NewURI("testdata/library.complex.ecore"))
 	require.NotNil(t, resource)
 	result := xmiProcessor.SaveToString(resource, nil)
 	// check
@@ -58,7 +58,7 @@ func BenchmarkXMIEncoderLibrarySimple(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		resource := NewEResourceImpl()
-		resource.SetURI(&URI{Path: "testdata/library.simple.ecore"})
+		resource.SetURI(NewURI("testdata/library.simple.ecore"))
 		resource.Load()
 
 		var strbuff strings.Builder
@@ -71,7 +71,7 @@ func BenchmarkXMIEncoderLibraryNoRoot(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		resource := NewEResourceImpl()
-		resource.SetURI(&URI{Path: "testdata/library.noroot.ecore"})
+		resource.SetURI(NewURI("testdata/library.noroot.ecore"))
 		resource.Load()
 
 		var strbuff strings.Builder

--- a/ecore/xmldecoder.go
+++ b/ecore/xmldecoder.go
@@ -668,7 +668,7 @@ func (l *XMLDecoder) handleProxy(eProxy EObject, id string) {
 	// set object proxy uri
 	eProxy.(EObjectInternal).ESetProxyURI(uri)
 
-	if *resourceURI == *uri.TrimFragment() {
+	if resourceURI.Equals(uri.TrimFragment()) {
 		l.sameDocumentProxies = append(l.sameDocumentProxies, eProxy)
 	}
 }

--- a/ecore/xmldecoder.go
+++ b/ecore/xmldecoder.go
@@ -679,7 +679,7 @@ func (l *XMLDecoder) handleReferences() {
 			eReference := itRef.Next().(EReference)
 			eOpposite := eReference.GetEOpposite()
 			if eOpposite != nil && eOpposite.IsChangeable() && eProxy.EIsSet(eReference) {
-				resolvedObject := l.resource.GetEObject(eProxy.(EObjectInternal).EProxyURI().Fragment)
+				resolvedObject := l.resource.GetEObject(eProxy.(EObjectInternal).EProxyURI().Fragment())
 				if resolvedObject != nil {
 					var proxyHolder EObject
 					if eReference.IsMany() {

--- a/ecore/xmldecoder_test.go
+++ b/ecore/xmldecoder_test.go
@@ -23,7 +23,7 @@ import (
 
 func loadPackage(packageFileName string) EPackage {
 	xmiProcessor := NewXMIProcessor()
-	eResource := xmiProcessor.Load(&URI{Path: "testdata/" + packageFileName})
+	eResource := xmiProcessor.Load(NewURI("testdata/" + packageFileName))
 	if eResource.IsLoaded() && eResource.GetContents().Size() > 0 {
 		ePackage, _ := eResource.GetContents().Get(0).(EPackage)
 		return ePackage
@@ -39,7 +39,7 @@ func TestXMLDecoderLibraryNoRoot(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/library.noroot.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/library.noroot.xml"))
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -63,7 +63,7 @@ func TestXMLDecoderLibraryComplex(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/library.complex.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/library.complex.xml"))
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -120,7 +120,7 @@ func TestXMLDecoderLibraryComplexWithOptions(t *testing.T) {
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
 	eResource := xmlProcessor.LoadWithOptions(
-		&URI{Path: "testdata/library.complex.noroot.xml"},
+		NewURI("testdata/library.complex.noroot.xml"),
 		map[string]interface{}{
 			XML_OPTION_SUPPRESS_DOCUMENT_ROOT: true,
 			XML_OPTION_EXTENDED_META_DATA:     NewExtendedMetaData()})
@@ -146,7 +146,7 @@ func TestXMLDecoderSimpleInvalidXML(t *testing.T) {
 	require.NotNil(t, ePackage)
 
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/library.simple.invalid.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/library.simple.invalid.xml"))
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.False(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -158,7 +158,7 @@ func TestXMLDecoderSimpleEscapeXML(t *testing.T) {
 	require.NotNil(t, ePackage)
 
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/library.simple.escape.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/library.simple.escape.xml"))
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -183,7 +183,7 @@ func TestXMLDecoderSimpleXMLWithIDs(t *testing.T) {
 
 	eResourceSet := NewEResourceSetImpl()
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
-	eResource := eResourceSet.CreateResource(&URI{Path: "testdata/library.simple.ids.xml"})
+	eResource := eResourceSet.CreateResource(NewURI("testdata/library.simple.ids.xml"))
 	require.NotNil(t, eResource)
 	eResource.SetObjectIDManager(idManager)
 	eResource.LoadWithOptions(map[string]interface{}{XML_OPTION_ID_ATTRIBUTE_NAME: "id"})
@@ -217,7 +217,7 @@ func TestXMLDecoderSimpleXMLWithEDataTypeList(t *testing.T) {
 
 	eResourceSet := NewEResourceSetImpl()
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
-	eResource := eResourceSet.CreateResource(&URI{Path: "testdata/library.datalist.xml"})
+	eResource := eResourceSet.CreateResource(NewURI("testdata/library.datalist.xml"))
 	require.NotNil(t, eResource)
 	eResource.Load()
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -256,7 +256,7 @@ func TestXMLDecoderLibraryComplexBig(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.LoadWithOptions(&URI{Path: "testdata/library.complex.big.xml"}, nil)
+	eResource := xmlProcessor.LoadWithOptions(NewURI("testdata/library.complex.big.xml"), nil)
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -275,7 +275,7 @@ func TestXMLDecoderSimpleObject(t *testing.T) {
 
 	eResourceSet := NewEResourceSetImpl()
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
-	eResource := eResourceSet.CreateResource(&URI{Path: "$tmp.xml"})
+	eResource := eResourceSet.CreateResource(NewURI("$tmp.xml"))
 
 	f, err := os.Open("testdata/book.simple.xml")
 	require.NotNil(t, f)
@@ -295,7 +295,7 @@ func TestXMLDecoderMaps(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.LoadWithOptions(&URI{Path: "testdata/emap.xml"}, nil)
+	eResource := xmlProcessor.LoadWithOptions(NewURI("testdata/emap.xml"), nil)
 	require.NotNil(t, eResource)
 	require.True(t, eResource.IsLoaded())
 	require.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -377,7 +377,7 @@ func BenchmarkXMLDecoderLibraryComplexBig(b *testing.B) {
 	require.NotNil(b, ePackage)
 
 	// create resource
-	uri := &URI{Path: "testdata/library.complex.big.xml"}
+	uri := NewURI("testdata/library.complex.big.xml")
 	eResource := NewEResourceImpl()
 	eResource.SetURI(uri)
 	eResourceSet := NewEResourceSetImpl()
@@ -385,7 +385,7 @@ func BenchmarkXMLDecoderLibraryComplexBig(b *testing.B) {
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
 
 	// get file content
-	content, err := ioutil.ReadFile(uri.Path)
+	content, err := ioutil.ReadFile(uri.String())
 	require.Nil(b, err)
 	r := bytes.NewReader(content)
 

--- a/ecore/xmlencoder.go
+++ b/ecore/xmlencoder.go
@@ -787,16 +787,7 @@ func (s *XMLEncoder) getHRef(eObject EObject) string {
 }
 
 func (s *XMLEncoder) getResourceHRef(resource EResource, object EObject) *URI {
-	uri := resource.GetURI()
-	return BuildURI(
-		Scheme(uri.Scheme()),
-		Username(uri.Username()),
-		Password(uri.Password()),
-		Host(uri.Host()),
-		Port(uri.Port()),
-		Path(uri.Path()),
-		Fragment(resource.GetURIFragment(object)),
-	)
+	return NewURIBuilder(resource.GetURI()).SetFragment(resource.GetURIFragment(object)).URI()
 }
 
 func (s *XMLEncoder) getIDRef(eObject EObject) string {

--- a/ecore/xmlencoder.go
+++ b/ecore/xmlencoder.go
@@ -787,9 +787,16 @@ func (s *XMLEncoder) getHRef(eObject EObject) string {
 }
 
 func (s *XMLEncoder) getResourceHRef(resource EResource, object EObject) *URI {
-	uri := resource.GetURI().Copy()
-	uri.Fragment = resource.GetURIFragment(object)
-	return uri
+	uri := resource.GetURI()
+	return BuildURI(
+		Scheme(uri.Scheme()),
+		Username(uri.Username()),
+		Password(uri.Password()),
+		Host(uri.Host()),
+		Port(uri.Port()),
+		Path(uri.Path()),
+		Fragment(resource.GetURIFragment(object)),
+	)
 }
 
 func (s *XMLEncoder) getIDRef(eObject EObject) string {

--- a/ecore/xmlencoder_test.go
+++ b/ecore/xmlencoder_test.go
@@ -27,14 +27,14 @@ func TestXMLEncoderLibraryNoRootWithOptions(t *testing.T) {
 	// load resource
 	options := map[string]interface{}{XML_OPTION_SUPPRESS_DOCUMENT_ROOT: true, XML_OPTION_EXTENDED_META_DATA: NewExtendedMetaData()}
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.LoadWithOptions(&URI{Path: "testdata/library.noroot.xml"}, options)
+	eResource := xmlProcessor.LoadWithOptions(NewURI("testdata/library.noroot.xml"), options)
 	require.NotNil(t, eResource)
 	assert.True(t, eResource.IsLoaded())
 	assert.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
 	assert.True(t, eResource.GetWarnings().Empty(), diagnosticError(eResource.GetWarnings()))
 
 	// save
-	eResource.SetURI(&URI{Path: "testdata/library.noroot.result.xml"})
+	eResource.SetURI(NewURI("testdata/library.noroot.result.xml"))
 	xmlProcessor.SaveWithOptions(eResource, options)
 
 	// result
@@ -85,7 +85,7 @@ func TestXMLEncoderLibraryComplex(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/library.complex.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/library.complex.xml"))
 	require.NotNil(t, eResource)
 	assert.True(t, eResource.IsLoaded())
 	assert.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -105,7 +105,7 @@ func TestXMLEncoderEMaps(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/emap.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/emap.xml"))
 	require.NotNil(t, eResource)
 	assert.True(t, eResource.IsLoaded())
 	assert.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -125,7 +125,7 @@ func TestXMLEncoderLibraryComplexSubElement(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/library.complex.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/library.complex.xml"))
 	require.NotNil(t, eResource)
 	assert.True(t, eResource.IsLoaded())
 	assert.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -137,7 +137,7 @@ func TestXMLEncoderLibraryComplexSubElement(t *testing.T) {
 	require.NotNil(t, eContainer)
 
 	// create a new resource
-	eNewResource := eResource.GetResourceSet().CreateResource(&URI{Path: "testdata/library.complex.sub.xml"})
+	eNewResource := eResource.GetResourceSet().CreateResource(NewURI("testdata/library.complex.sub.xml"))
 	// add object to new resource
 	eNewResource.GetContents().Add(eObject)
 	// save it
@@ -167,7 +167,7 @@ func TestXMLEncoderLibraryComplexWithOptions(t *testing.T) {
 
 	// load resource
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.LoadWithOptions(&URI{Path: "testdata/library.complex.noroot.xml"}, options)
+	eResource := xmlProcessor.LoadWithOptions(NewURI("testdata/library.complex.noroot.xml"), options)
 	require.NotNil(t, eResource)
 	assert.True(t, eResource.IsLoaded())
 	assert.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -197,7 +197,7 @@ func TestXMLEncoderSimpleEscapeXML(t *testing.T) {
 	eLibrary.ESet(eLibraryLocationAttribute, "a<b")
 
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.GetResourceSet().CreateResource(&URI{Path: "testdata/library.simple.escape.output.xml"})
+	eResource := xmlProcessor.GetResourceSet().CreateResource(NewURI("testdata/library.simple.escape.output.xml"))
 	eResource.GetContents().Add(eLibrary)
 	result := xmlProcessor.SaveToString(eResource, nil)
 
@@ -214,7 +214,7 @@ func TestXMLEncoderSimpleXMLWithIDs(t *testing.T) {
 
 	eResourceSet := NewEResourceSetImpl()
 	eResourceSet.GetPackageRegistry().RegisterPackage(ePackage)
-	eResource := eResourceSet.CreateResource(&URI{Path: "testdata/library.simple.xml"})
+	eResource := eResourceSet.CreateResource(NewURI("testdata/library.simple.xml"))
 	require.NotNil(t, eResource)
 	eResource.SetObjectIDManager(NewIncrementalIDManager())
 	eResource.Load()
@@ -236,7 +236,7 @@ func TestXMLEncoderSimpleXMLWithEDataTypeList(t *testing.T) {
 	assert.NotNil(t, ePackage)
 
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/library.datalist.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/library.datalist.xml"))
 	require.NotNil(t, eResource)
 	assert.True(t, eResource.IsLoaded())
 	assert.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -256,7 +256,7 @@ func TestXMLEncoderSimpleXMLRootObjects(t *testing.T) {
 
 	// load model file
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/library.simple.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/library.simple.xml"))
 	require.NotNil(t, eResource)
 	assert.True(t, eResource.IsLoaded())
 	assert.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -292,7 +292,7 @@ func TestXMLEncoderSimpleObject(t *testing.T) {
 
 	// load model file
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/library.simple.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/library.simple.xml"))
 	require.NotNil(t, eResource)
 	assert.True(t, eResource.IsLoaded())
 	assert.True(t, eResource.GetErrors().Empty(), diagnosticError(eResource.GetErrors()))
@@ -326,7 +326,7 @@ func BenchmarkXMLEncoderLibraryComplexBig(b *testing.B) {
 	ePackage := loadPackage("library.complex.ecore")
 	require.NotNil(b, ePackage)
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	eResource := xmlProcessor.Load(&URI{Path: "testdata/library.complex.big.xml"})
+	eResource := xmlProcessor.Load(NewURI("testdata/library.complex.big.xml"))
 	require.NotNil(b, eResource)
 	for i := 0; i < b.N; i++ {
 		var strbuff strings.Builder

--- a/ecore/xmlprocessor.go
+++ b/ecore/xmlprocessor.go
@@ -60,7 +60,7 @@ func (p *XMLProcessor) LoadWithOptions(uri *URI, options map[string]interface{})
 
 func (p *XMLProcessor) LoadWithReader(r io.Reader, options map[string]interface{}) EResource {
 	rs := p.GetResourceSet()
-	rc := rs.CreateResource(&URI{Path: "*.xml"})
+	rc := rs.CreateResource(NewURI("*.xml"))
 	o := map[string]interface{}{XML_OPTION_EXTENDED_META_DATA: p.extendMetaData}
 	if options != nil {
 		for k, v := range options {

--- a/ecore/xmlprocessor_test.go
+++ b/ecore/xmlprocessor_test.go
@@ -34,7 +34,7 @@ func TestNewSharedXmlProcessor(t *testing.T) {
 }
 
 func xmlProcessorLoad(t *testing.T, xmlProcessor *XMLProcessor, path string) EObject {
-	resource := xmlProcessor.Load(&URI{Path: path})
+	resource := xmlProcessor.Load(NewURI(path))
 	require.NotNil(t, resource)
 	require.True(t, resource.GetErrors().Empty(), diagnosticError(resource.GetErrors()))
 	eObject, _ := resource.GetContents().Get(0).(EObject)
@@ -65,7 +65,7 @@ func TestSaveObject(t *testing.T) {
 			require.NotNil(t, eModel)
 
 			resultName := "testdata/" + testCase.name + ".result.xml"
-			xmlProcessor.SaveObject(&URI{Path: resultName}, eModel)
+			xmlProcessor.SaveObject(NewURI(resultName), eModel)
 
 			// src
 			src, err := ioutil.ReadFile("testdata/" + testCase.model)
@@ -118,5 +118,5 @@ func _TestSerializationTree(t *testing.T) {
 	eNode := f.newNode("0", 5)
 
 	xmlProcessor := NewXMLProcessor([]EPackage{ePackage})
-	xmlProcessor.SaveObject(&URI{Path: "testdata/tree.xml"}, eNode)
+	xmlProcessor.SaveObject(NewURI("testdata/tree.xml"), eNode)
 }

--- a/test/library/serialization_test.go
+++ b/test/library/serialization_test.go
@@ -126,7 +126,7 @@ func TestDeepOperations(t *testing.T) {
 
 func BenchmarkXMLDecoderLibraryComplexBig(b *testing.B) {
 	// create resource
-	uri := &ecore.URI{Path: "testdata/library.complex.xml"}
+	uri := ecore.CreateFileURI("testdata/library.complex.xml")
 	eResource := ecore.NewEResourceImpl()
 	eResource.SetURI(uri)
 	eResourceSet := ecore.NewEResourceSetImpl()
@@ -134,7 +134,7 @@ func BenchmarkXMLDecoderLibraryComplexBig(b *testing.B) {
 	eResourceSet.GetPackageRegistry().RegisterPackage(GetPackage())
 
 	// get file content
-	content, err := ioutil.ReadFile(uri.Path)
+	content, err := ioutil.ReadFile(uri.String())
 	require.Nil(b, err)
 	r := bytes.NewReader(content)
 
@@ -149,7 +149,7 @@ func BenchmarkXMLDecoderLibraryComplexBig(b *testing.B) {
 func BenchmarkXMLEncoderLibraryComplexBig(b *testing.B) {
 	// load resource
 	xmlProcessor := ecore.NewXMLProcessor([]ecore.EPackage{GetPackage()})
-	eResource := xmlProcessor.LoadWithOptions(&ecore.URI{Path: "testdata/library.complex.xml"}, nil)
+	eResource := xmlProcessor.LoadWithOptions(ecore.CreateFileURI("testdata/library.complex.xml"), nil)
 	require.NotNil(b, eResource)
 	require.True(b, eResource.GetWarnings().Empty(), diagnosticError(eResource.GetWarnings()))
 
@@ -163,7 +163,7 @@ func BenchmarkXMLEncoderLibraryComplexBig(b *testing.B) {
 
 func BenchmarkBinaryDecoderLibraryComplexBig(b *testing.B) {
 	// create resource
-	uri := &ecore.URI{Path: "testdata/library.complex.bin"}
+	uri := ecore.CreateFileURI("testdata/library.complex.bin")
 	eResource := ecore.NewEResourceImpl()
 	eResource.SetURI(uri)
 	eResourceSet := ecore.NewEResourceSetImpl()
@@ -171,7 +171,7 @@ func BenchmarkBinaryDecoderLibraryComplexBig(b *testing.B) {
 	eResourceSet.GetPackageRegistry().RegisterPackage(GetPackage())
 
 	// get file content
-	content, err := ioutil.ReadFile(uri.Path)
+	content, err := ioutil.ReadFile(uri.String())
 	require.Nil(b, err)
 	r := bytes.NewReader(content)
 
@@ -186,7 +186,7 @@ func BenchmarkBinaryDecoderLibraryComplexBig(b *testing.B) {
 func BenchmarkBinaryEncoderLibraryComplexBig(b *testing.B) {
 	// load resource
 	xmlProcessor := ecore.NewXMLProcessor([]ecore.EPackage{GetPackage()})
-	eResource := xmlProcessor.LoadWithOptions(&ecore.URI{Path: "testdata/library.complex.xml"}, nil)
+	eResource := xmlProcessor.LoadWithOptions(ecore.CreateFileURI("testdata/library.complex.xml"), nil)
 	require.NotNil(b, eResource)
 	require.True(b, eResource.GetWarnings().Empty(), diagnosticError(eResource.GetWarnings()))
 


### PR DESCRIPTION
define URIBuilder struct as a an URI builder.
URI paremeters can be defined and set only with the URIBuilder
URI stores internally the string representation of the uri