### PR TITLE
EResource.GetAllContents ignores inherited features

### DIFF
--- a/ecore/basiceobject_impl.go
+++ b/ecore/basiceobject_impl.go
@@ -86,7 +86,7 @@ func (o *BasicEObjectImpl) EContents() EList {
 	properties := o.getObjectProperties()
 	if properties.contents == nil {
 		eObject := o.AsEObject()
-		properties.contents = newEContentsList(eObject, eObject.EClass().GetEContainmentFeatures(), true)
+		properties.contents = newEContentsList(eObject, eObject.EClass().GetEAllContainments(), true)
 	}
 	return properties.contents
 }


### PR DESCRIPTION
I noticed that when I traverse a model some elements has been ignored by the tree iterator. Specifically, when an object's containing feature is not a direct feature of the container object's class but one of its sublass, it is ignored. The solution is to use `EClass.GetEAllContainments` instead of `EClass.GetEContainmentFeatures` in the implementation of `BasicEObjectImpl.EContents`